### PR TITLE
Navigation component

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
       "last 1 safari version"
     ]
   },
+  "proxy": "http://localhost:8080",
   "description": "This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).",
   "main": "deploy-dev.js",
   "devDependencies": {},

--- a/src/App/App.js
+++ b/src/App/App.js
@@ -1,10 +1,12 @@
 import React from "react";
 import "./App.module.css";
 import HabitList from "../containers/HabitList/HabitList";
+import NavigationComponent from "../containers/NavigationComponent.jsx/NavigationComponent";
 
 function App() {
   return (
     <div>
+      <NavigationComponent />
       <HabitList />
     </div>
   );

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,6 +1,7 @@
 export const TOGGLE = "TOGGLE";
 
-export const actionsToggle = link => {
+export const actionsToggle = link => dispatch => {
+  console.log("click being sent to reducer");
   return dispatch({
     type: TOGGLE,
     payload: link

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,0 +1,8 @@
+export const TOGGLE = "TOGGLE";
+
+export const actionsToggle = link => {
+  return dispatch({
+    type: TOGGLE,
+    payload: link
+  });
+};

--- a/src/containers/NavigationComponent.jsx/NavigationComponent.jsx
+++ b/src/containers/NavigationComponent.jsx/NavigationComponent.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import { connect } from "react-redux";
+import { actionsToggle } from "../../actions";
 
 class NavigationComponent extends Component {
   constructor(props) {
@@ -7,78 +8,72 @@ class NavigationComponent extends Component {
     this.state = {};
   }
 
+  handleHomepageClick = () => {
+    this.props.toggle("homepage");
+  };
+
+  handleHygieneClick = () => {
+    this.props.toggle("hygiene");
+  };
+
+  handleHomeClick = () => {
+    this.props.toggle("home");
+  };
+
+  handleSocialClick = () => {
+    this.props.toggle("social");
+  };
+
+  handleWorkClick = () => {
+    this.props.toggle("work");
+  };
+
+  handleViewAllClick = () => {
+    this.props.toggle("viewAll");
+  };
   render() {
     return (
       <nav className="navigation">
-        <li
-          className="link"
-          onClick={function() {
-            props.toggle("homepage");
-          }}
-        >
+        <li className="link" onClick={this.handleHomepageClick}>
           Homepage
         </li>
-        <li
-          className="link"
-          onClick={function() {
-            props.toggle("hygiene");
-          }}
-        >
+        <li className="link" onClick={this.handleHygieneClick}>
           Hygiene
         </li>
-        <li
-          className="link"
-          onClick={function() {
-            props.toggle("work");
-          }}
-        >
+        <li className="link" onClick={this.handleWorkClick}>
           Work
         </li>
-        <li
-          className="link"
-          onClick={function() {
-            props.toggle("home");
-          }}
-        >
+        <li className="link" onClick={this.handleHomeClick}>
           Home
         </li>
-        <li
-          className="link"
-          onClick={function() {
-            props.toggle("social");
-          }}
-        >
+        <li className="link" onClick={this.handleSocialClick}>
           Social
         </li>
-        <li
-          className="link"
-          onClick={function() {
-            props.toggle("viewAll");
-          }}
-        >
+        <li className="link" onClick={this.handleViewAllClick}>
           View All
         </li>
-        <p>{this.props.display}</p>
       </nav>
     );
   }
 }
 
 const mapStateToProps = store => {
+  console.log(store.display);
   return {
     display: store.display
   };
 };
 
-const mapDispatchToProps = () => {
+const mapDispatchToProps = dispatch => {
   return {
     toggle: link => {
+      console.log("sending click to actions");
       return dispatch(actionsToggle(link));
     }
   };
 };
 
-NavigationComponeent = connect(
+NavigationComponent = connect(
   mapStateToProps,
   mapDispatchToProps
 )(NavigationComponent);

--- a/src/containers/NavigationComponent.jsx/NavigationComponent.jsx
+++ b/src/containers/NavigationComponent.jsx/NavigationComponent.jsx
@@ -1,22 +1,86 @@
 import React, { Component } from "react";
+import { connect } from "react-redux";
 
 class NavigationComponent extends Component {
   constructor(props) {
     super(props);
     this.state = {};
   }
+
   render() {
     return (
       <nav className="navigation">
-        <li className="link">Home</li>
-        <li className="link">Category 1</li>
-        <li className="link">Category 2</li>
-        <li className="link">Category 3</li>
-        <li className="link">Category 4</li>
-        <li className="link">Category 5</li>
+        <li
+          className="link"
+          onClick={function() {
+            props.toggle("homepage");
+          }}
+        >
+          Homepage
+        </li>
+        <li
+          className="link"
+          onClick={function() {
+            props.toggle("hygiene");
+          }}
+        >
+          Hygiene
+        </li>
+        <li
+          className="link"
+          onClick={function() {
+            props.toggle("work");
+          }}
+        >
+          Work
+        </li>
+        <li
+          className="link"
+          onClick={function() {
+            props.toggle("home");
+          }}
+        >
+          Home
+        </li>
+        <li
+          className="link"
+          onClick={function() {
+            props.toggle("social");
+          }}
+        >
+          Social
+        </li>
+        <li
+          className="link"
+          onClick={function() {
+            props.toggle("viewAll");
+          }}
+        >
+          View All
+        </li>
+        <p>{this.props.display}</p>
       </nav>
     );
   }
 }
+
+const mapStateToProps = store => {
+  return {
+    display: store.display
+  };
+};
+
+const mapDispatchToProps = () => {
+  return {
+    toggle: link => {
+      return dispatch(actionsToggle(link));
+    }
+  };
+};
+
+NavigationComponeent = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(NavigationComponent);
 
 export default NavigationComponent;

--- a/src/containers/NavigationComponent.jsx/NavigationComponent.jsx
+++ b/src/containers/NavigationComponent.jsx/NavigationComponent.jsx
@@ -1,0 +1,22 @@
+import React, { Component } from "react";
+
+class NavigationComponent extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {};
+  }
+  render() {
+    return (
+      <nav className="navigation">
+        <li className="link">Home</li>
+        <li className="link">Category 1</li>
+        <li className="link">Category 2</li>
+        <li className="link">Category 3</li>
+        <li className="link">Category 4</li>
+        <li className="link">Category 5</li>
+      </nav>
+    );
+  }
+}
+
+export default NavigationComponent;

--- a/src/containers/NavigationComponent.jsx/index.js
+++ b/src/containers/NavigationComponent.jsx/index.js
@@ -1,0 +1,2 @@
+import NavigationComponent from "./NavigationComponent";
+export default NavigationComponent;

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,31 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import './index.css';
-import App from './App/App';
-import * as serviceWorker from './serviceWorker';
+import React from "react";
+import ReactDOM from "react-dom";
+import "./index.css";
+import App from "./App/App";
+import * as serviceWorker from "./serviceWorker";
+import { Provider } from "react-redux";
+import { createStore, applyMiddleware, compose } from "redux";
+import ReduxThunk from "redux-thunk";
+import reducer from "./reducers";
 
-ReactDOM.render(<App />, document.getElementById('root'));
+const composeEnhancers =
+  typeof window === "object" && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
+    ? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({
+        // Specify extension's options like name, actionsBlacklist, actionsCreators, serialize...
+      })
+    : compose;
+
+const enhancer = composeEnhancers(applyMiddleware(ReduxThunk)); //applyMiddleware to connect redux
+
+const store = createStore(reducer, enhancer);
+
+ReactDOM.render(
+  //Provider v wraps around the App and gives it access to the store;
+  <Provider store={store}>
+    <App />
+  </Provider>,
+  document.getElementById("root")
+);
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,0 +1,33 @@
+import { TOGGLE } from "../actions";
+
+let globalState = {
+  display: {
+    hompage: false,
+    hygiene: false,
+    work: false,
+    home: false,
+    social: false,
+    viewAll: false
+  }
+};
+
+const reducer = (state = globalState, action) => {
+  switch (action.type) {
+    case TOGGLE:
+      let toggleDisplay = state.display;
+
+      for (let key in toggleDisplay) {
+        if (key !== action.payload) {
+          toggleDisplay[key] = false;
+        } else {
+          toggleDisplay[key] = true;
+        }
+      }
+      return Object.assign({}, state, { display: toggleDisplay });
+
+    default:
+      return state;
+  }
+};
+
+export default reducer;

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -2,7 +2,8 @@ import { TOGGLE } from "../actions";
 
 let globalState = {
   display: {
-    hompage: false,
+    //the components that correspond to the values below can tap into this object to self-determine if they should be displayed or hidden, which I believe should be done on componentDidMount?
+    homepage: false,
     hygiene: false,
     work: false,
     home: false,
@@ -14,6 +15,7 @@ let globalState = {
 const reducer = (state = globalState, action) => {
   switch (action.type) {
     case TOGGLE:
+      console.log("reducer is handling click");
       let toggleDisplay = state.display;
 
       for (let key in toggleDisplay) {


### PR DESCRIPTION
This component is set up to exist at the App level, the same level as the HabitList component.  It has functionality to toggle a global state property called display, which houses boolean values that represent the open state of the other UnAuth components (i.e. a true values = open, false = closed);

This component does not reach into server.

test it:
- [x] open project in browser
- [x] open console
- [x] click on any of the links
- [x] you should see a console log of the this.props.display, and all values should be toggled to false expect for the one you clicked on.

it can be tested further when the other components have foundational builds and are ready to receive open/close functionality.